### PR TITLE
Use more informative link text for git alias links

### DIFF
--- a/episodes/02-branching_merging.md
+++ b/episodes/02-branching_merging.md
@@ -126,17 +126,15 @@ them and how to merge changes from different branches.
 
 ## A useful alias
 
-We will now define an *alias* in Git, to be able to nicely visualise branch
-structure in the terminal without having to remember a long Git command:
+We will now define an [*alias* in Git](https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases),
+to be able to nicely visualise branch structure in the terminal without having to
+remember a long Git command:
 
 ```bash
 git config --global alias.graph "log --all --graph --decorate --oneline"
 ```
 
-We can now abbreviate `log --all --graph --decorate --oneline` with the alias `graph`
-([bash aliases](https://linuxize.com/post/how-to-create-bash-aliases/) <!-- markdown-link-check-disable-line -->
-and
-[how to set them up in Git](https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases)).
+We can now abbreviate `log --all --graph --decorate --oneline` with the alias `graph`.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 


### PR DESCRIPTION
According to [web accessibility guidelines](https://webaim.org/techniques/hypertext/link_text#uninformative), it is bad practice to have, for example "see information on something `[here](url-to-site-containing-information-on-thing)`". We were getting warnings about this for our link text to bash aliases and using them with git commands, so this PR tries to address this.

I'm not convinced it reads better, but perhaps it works better for screen readers, so I moved the text around a bit, with some further explanatory text.

Closes #137 