### PR TITLE
Remove unnecessary `sleep` from docker compose config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,9 @@ services:
       WORKBENCH_PROFILE: "local"
     ports:
       - 127.0.0.1:4321:4321
-    entrypoint: ["/bin/bash"]
+    entrypoint: ["/bin/sh"]
     command:
       - -c
-      - |
-        sleep 10
-        Rscript -e 'sandpaper::serve("/home/rstudio/lessons/rse_further_git_course", host="0.0.0.0")'
+      - Rscript -e 'sandpaper::serve("/home/rstudio/lessons/rse_further_git_course", host="0.0.0.0")'
     volumes:
       - ./:/home/rstudio/lessons/rse_further_git_course


### PR DESCRIPTION
It looks to me like the `sleep 10` in the Docker compose config is unnecessary and just means that the server takes another 10s to start up, so I've removed it. The service doesn't depend on anything other than the volumes, which should be there on startup anyway.

@SaranjeetKaur I might be wrong about this! If it doesn't work for you without the `sleep`, let me know.