### PR TITLE
`CONTRIBUTING.md` fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ renv/sandbox/
 __pycache__
 _site
 .Rproj.user
+
+# python virtual environment
+.venv/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,20 +1,19 @@
-## Contributing
+# Contributing
 
-[The Carpentries][cp-site] ([Software Carpentry][swc-site], [Data
-Carpentry][dc-site], and [Library Carpentry][lc-site]) are open source
-projects, and we welcome contributions of all kinds: new lessons, fixes to
+The Further Git and GitHub for Effective Collaboration course is an [open source
+project][repo], and we welcome contributions of all kinds: fixes to
 existing material, bug reports, and reviews of proposed changes are all
 welcome.
 
-### Contributor Agreement
+## Contributor Agreement
 
 By contributing, you agree that we may redistribute your work under [our
 license](LICENSE.md). In exchange, we will address your issues and/or assess
 your change proposal as promptly as we can, and help you become a member of our
-community. Everyone involved in [The Carpentries][cp-site] agrees to abide by
+community. Every contributor agrees to abide by
 our [code of conduct](CODE_OF_CONDUCT.md).
 
-### How to Contribute
+## How to Contribute
 
 The easiest way to get started is to file an issue to tell us about a spelling
 mistake, some awkward wording, or a factual error. This is a good way to
@@ -32,26 +31,25 @@ introduce yourself and to meet some of our community members.
 3. If you are comfortable with Git, and would like to add or change material,
    you can submit a pull request (PR). Instructions for doing this are
    [included below](#using-github). For inspiration about changes that need to
-   be made, check out the [list of open issues][issues] across the Carpentries.
+   be made, check out the [list of open issues][issues].
 
 Note: if you want to build the website locally, please refer to [The Workbench
 documentation][template-doc].
 
-### Where to Contribute
+## Where to Contribute
 
 1. If you wish to change this lesson, add issues and pull requests here.
 2. If you wish to change the template used for workshop websites, please refer
    to [The Workbench documentation][template-doc].
 
 
-### What to Contribute
+## What to Contribute
 
 There are many ways to contribute, from writing new exercises and improving
 existing ones to updating or filling in the documentation and submitting [bug
 reports][issues] about things that do not work, are not clear, or are missing.
 If you are looking for ideas, please see [the list of issues for this
-repository][repo-issues], or the issues for [Data Carpentry][dc-issues],
-[Library Carpentry][lc-issues], and [Software Carpentry][swc-issues] projects.
+repository][repo-issues].
 
 Comments on issues and reviews of pull requests are just as welcome: we are
 smarter together than we are on our own. **Reviews from novices and newcomers
@@ -59,7 +57,7 @@ are particularly valuable**: it's easy for people who have been using these
 lessons for a while to forget how impenetrable some of this material can be, so
 fresh eyes are always welcome.
 
-### What *Not* to Contribute
+## What *Not* to Contribute
 
 Our lessons already contain more material than we can cover in a typical
 workshop, so we are usually *not* looking for more concepts or tools to add to
@@ -73,7 +71,7 @@ platform. Our workshops typically contain a mixture of Windows, macOS, and
 Linux users; in order to be usable, our lessons must run equally well on all
 three.
 
-### Using GitHub
+## Using GitHub
 
 If you choose to contribute via GitHub, you may want to look at [How to
 Contribute to an Open Source Project on GitHub][how-contribute]. In brief, we
@@ -93,18 +91,19 @@ Each lesson has a team of maintainers who review issues and pull requests or
 encourage others to do so. The maintainers are community volunteers, and have
 final say over what gets merged into the lesson.
 
-### Other Resources
+## Other Resources
 
 The Carpentries is a global organisation with volunteers and learners all over
 the world. We share values of inclusivity and a passion for sharing knowledge,
 teaching and learning. There are several ways to connect with The Carpentries
 community listed at <https://carpentries.org/connect/> including via social
-media, slack, newsletters, and email lists. You can also [reach us by
-email][contact].
+media, slack, newsletters, and email lists.
 
-[repo]: https://example.com/FIXME
-[repo-issues]: https://example.com/FIXME/issues
-[contact]: mailto:team@carpentries.org
+You can also [reach the RSE team by email][contact].
+
+[repo]: https://github.com/ImperialCollegeLondon/rse_further_git_course
+[repo-issues]: https://github.com/ImperialCollegeLondon/rse_further_git_course/issues
+[contact]: mailto:ict-rse-team@imperial.ac.uk
 [cp-site]: https://carpentries.org/
 [dc-issues]: https://github.com/issues?q=user%3Adatacarpentry
 [dc-lessons]: https://datacarpentry.org/lessons/

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4,8 +4,7 @@ title: "Licenses"
 
 ## Instructional Material
 
-All Carpentries (Software Carpentry, Data Carpentry, and Library Carpentry)
-instructional material is made available under the [Creative Commons
+The Further Git and GitHub for Effective Collaboration course is made available under the [Creative Commons
 Attribution license][cc-by-human]. The following is a human-readable summary of
 (and not a substitute for) the [full legal text of the CC BY 4.0
 license][cc-by-legal].


### PR DESCRIPTION
Updates the `CONTRIBUTING.md` and `LICENSE.md` files to tailor them for the "Further Git and GitHub for Effective Collaboration" course, removing references to The Carpentries and updating contact and repository information.

Also add `.venv` to the `.gitignore`.

Closes #141 